### PR TITLE
Removed app mount from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       traefik.frontend.rule: "Host: discord.muncompsci.ca"
       traefik.port: 5000
       traefik.frontend.entryPoints: "https"
-    volumes:
-      - ./:/app
 networks:
   web:
     external: true


### PR DESCRIPTION
Removed app mount from docker-compose, allowing changes to take effect as soon as the build gets pulled down onto my server, rather than relying on me cloning the app.